### PR TITLE
enable OpenMP on linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,9 @@ on: [push, pull_request]
 
 env:
   BUILD_TYPE: Release
-  AVX2: OFF
-  AVX512: OFF
+  HAMMING_WITH_AVX2: OFF
+  HAMMING_WITH_AVX512: OFF
+  HAMMING_WITH_OPENMP: OFF
 
 jobs:
   build-and-test:
@@ -17,10 +18,13 @@ jobs:
         os: [ubuntu-18.04, macos-10.15, windows-2019]
 
     steps:
-    # clone the repo & any submodules
     - uses: actions/checkout@v2
       with:
         submodules: 'recursive'
+
+    - name: enable openmp on linux
+      run: echo "HAMMING_WITH_OPENMP=ON" >> $GITHUB_ENV
+      if: runner.os == 'Linux'
 
     - name: make build directory
       run: cmake -E make_directory ${{runner.workspace}}/build
@@ -28,7 +32,7 @@ jobs:
     - name: configure cmake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_TESTING=ON -DHAMMING_BUILD_BENCHMARKS=ON -DHAMMING_WITH_SSE2=ON -DHAMMING_WITH_AVX2=$AVX2 -DHAMMING_WITH_AVX512=$AVX512 -DHAMMING_BUILD_PYTHON=ON
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_TESTING=ON -DHAMMING_BUILD_BENCHMARKS=ON -DHAMMING_WITH_SSE2=ON -DHAMMING_WITH_AVX2=$HAMMING_WITH_AVX2 -DHAMMING_WITH_AVX512=$HAMMING_WITH_AVX512 -DHAMMING_BUILD_PYTHON=ON -DHAMMING_WITH_OPENMP=$HAMMING_WITH_OPENMP
 
     - name: build
       shell: bash

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,7 +9,9 @@ jobs:
     env:
       CIBW_TEST_REQUIRES: 'pytest numpy'
       CIBW_TEST_COMMAND: 'pytest {project}/python/tests'
-      CIBW_TEST_SKIP: "pp*"
+      CIBW_TEST_SKIP: 'pp*'
+      CIBW_SKIP: "*-manylinux_i686"
+      CIBW_BUILD_VERBOSITY: 3
 
     strategy:
       matrix:
@@ -19,6 +21,10 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'recursive'
+
+    - name: enable openmp on linux
+      run: echo 'CIBW_ENVIRONMENT=HAMMING_WITH_OPENMP=ON' >> $GITHUB_ENV
+      if: runner.os == 'Linux'
 
     - uses: pypa/cibuildwheel@v2.0.0
 

--- a/README.md
+++ b/README.md
@@ -51,5 +51,10 @@ data.dump_sequence_indices("indices.txt")
 data = hammingdist.from_stringlist(["ACGTACGT", "ACGTAGGT", "ATTTACGT"])
 ```
 
-The Python package is currently built without OpenMP support, but this can
-be changed upon request.
+## OpenMP on linux
+
+The latest version of hammingdist on linux is now built with OpenMP (multithreading) support.
+If this causes any issues, you can install the previous version of hammingdist without OpenMP support:
+```bash
+pip install hammingdist==0.11.0
+```

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ class CMakeBuild(build_ext):
                       '-DHAMMING_BUILD_PYTHON=ON',
                       '-DBUILD_TESTING=OFF',
                       '-DHAMMING_BUILD_BENCHMARKS=OFF',
-                      '-DHAMMING_WITH_OPENMP=OFF',
+                      '-DHAMMING_WITH_OPENMP=' + os.environ.get('HAMMING_WITH_OPENMP', 'OFF')
                      ]
 
         cfg = 'Debug' if self.debug else 'Release'
@@ -77,7 +77,7 @@ with open(path.join(path.abspath(path.dirname(__file__)), "README.md")) as f:
 
 setup(
     name='hammingdist',
-    version='0.11.0',
+    version='0.12.0',
     author='Dominic Kempf, Liam Keegan',
     author_email='ssc@iwr.uni-heidelberg.de',
     description='A fast tool to calculate Hamming distances',

--- a/src/hamming_t.cc
+++ b/src/hamming_t.cc
@@ -234,6 +234,9 @@ TEST_CASE("from_csv reproduces correct data", "[hamming]") {
     std::remove(tmp_file_name);
 }
 
+
+// skip this test of openmp is enabled: affects exception handling
+#ifndef HAMMING_WITH_OPENMP
 TEST_CASE("throws on distance integer overflow", "[hamming]") {
     auto n = std::numeric_limits<DistIntType>::max() + 1;
     std::mt19937 gen(12345);
@@ -243,6 +246,7 @@ TEST_CASE("throws on distance integer overflow", "[hamming]") {
     std::string msg{"Error: Distance is too large for chosen integer type"};
     REQUIRE_THROWS_WITH(DataSet(data), msg);
 }
+#endif
 
 TEST_CASE("from_lower_triangular reproduces correct data", "[hamming]") {
     std::mt19937 gen(12345);


### PR DESCRIPTION
- update readme
  - how to install previous non-openmp version of hammingdist
- enable in CI & in published wheels
  - remove 32-bit linux wheel builds
- skip test that catches exception if openmp is enabled
  - openmp affects exception handling
- bump version to 0.12.0
- resolves #17