### PR TITLE
add function to calculate distances from reference sequence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 env:
   BUILD_TYPE: Release

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,6 +1,12 @@
 name: Build Wheels + PyPI deploy
 
-on: [push, pull_request, release]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+  release:
 
 jobs:
   build-wheels:
@@ -8,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       CIBW_TEST_REQUIRES: "pytest numpy"
-      CIBW_TEST_COMMAND: "pytest {project}/python/tests"
+      CIBW_TEST_COMMAND: "pytest {project}/python/tests -v"
       CIBW_TEST_SKIP: "pp* *-musllinux*"
       CIBW_ENVIRONMENT: "BLAS=None LAPACK=None ATLAS=None"
       CIBW_SKIP: "*-manylinux_i686"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.11)
 include(CTest)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 
 # compilation options
 set(HAMMING_WITH_OPENMP

--- a/README.md
+++ b/README.md
@@ -51,10 +51,22 @@ data.dump_sequence_indices("indices.txt")
 data = hammingdist.from_stringlist(["ACGTACGT", "ACGTAGGT", "ATTTACGT"])
 ```
 
+## Distances from reference sequence
+
+The distance of each sequence in a fasta file from a given reference sequence can be calculated using:
+
+```python
+import hammingdist
+
+distances = hammingdist.fasta_reference_distances(sequence, fasta_file, include_x=True)
+```
+
+This function returns a numpy array that contains the distance of each sequence from the reference sequence.
+
 ## OpenMP on linux
 
 The latest version of hammingdist on linux is now built with OpenMP (multithreading) support.
-If this causes any issues, you can install the previous version of hammingdist without OpenMP support:
+If this causes any issues, you can install a previous version of hammingdist without OpenMP support:
 
 ```bash
 pip install hammingdist==0.11.0

--- a/include/hamming/hamming.hh
+++ b/include/hamming/hamming.hh
@@ -13,6 +13,11 @@ DataSet from_fasta(const std::string &, bool include_x = false,
                    bool remove_duplicates = false, std::size_t n = 0);
 DataSet from_lower_triangular(const std::string &);
 
+std::vector<ReferenceDistIntType>
+fasta_reference_distances(const std::string &reference_sequence,
+                          const std::string &fasta_file,
+                          bool include_x = false);
+
 } // namespace hamming
 
 #endif

--- a/include/hamming/hamming_types.hh
+++ b/include/hamming/hamming_types.hh
@@ -9,6 +9,7 @@
 namespace hamming {
 
 using DistIntType = uint8_t;
+using ReferenceDistIntType = uint32_t;
 
 struct DataSet {
   DataSet(std::vector<std::string> &, bool include_x = false,

--- a/python/hammingdist.cc
+++ b/python/hammingdist.cc
@@ -1,9 +1,27 @@
+#include <memory>
+#include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
 #include "hamming/hamming.hh"
 
 namespace py = pybind11;
+
+// helper function to avoid making a copy when returning a py::array_t
+// author: https://github.com/YannickJadoul
+// source: https://github.com/pybind/pybind11/issues/1042#issuecomment-642215028
+template <typename Sequence>
+inline py::array_t<typename Sequence::value_type> as_pyarray(Sequence &&seq) {
+  auto size = seq.size();
+  auto data = seq.data();
+  std::unique_ptr<Sequence> seq_ptr =
+      std::make_unique<Sequence>(std::move(seq));
+  auto capsule = py::capsule(seq_ptr.get(), [](void *p) {
+    std::unique_ptr<Sequence>(reinterpret_cast<Sequence *>(p));
+  });
+  seq_ptr.release();
+  return py::array(size, data, capsule);
+}
 
 namespace hamming {
 
@@ -33,6 +51,17 @@ PYBIND11_MODULE(hammingdist, m) {
   m.def("from_lower_triangular", &from_lower_triangular,
         "Creates a dataset by reading already computed distances from lower "
         "triangular format");
+  m.def(
+      "fasta_reference_distances",
+      [](const std::string &reference_sequence, const std::string &fasta_file,
+         bool include_x) {
+        return as_pyarray(fasta_reference_distances(reference_sequence,
+                                                    fasta_file, include_x));
+      },
+      py::arg("reference_sequence"), py::arg("fasta_file"),
+      py::arg("include_x") = false,
+      "Calculates the distance of each sequence in the fasta file from the "
+      "supplied reference sequence");
 }
 
 } // namespace hamming

--- a/python/tests/test_hammingdist.py
+++ b/python/tests/test_hammingdist.py
@@ -81,8 +81,8 @@ def test_from_fasta(tmp_path):
     ],
 )
 def test_fasta_reference_distances(chars, include_x, tmp_path):
-    # generate 1000 sequences, each with 250 characters
-    sequences = ["".join(random.choices(chars, k=250)) for i in range(1000)]
+    # generate 50 sequences, each with 25 characters
+    sequences = ["".join(random.choices(chars, k=25)) for i in range(50)]
     fasta_file = str(tmp_path / "fasta.txt")
     write_fasta_file(fasta_file, sequences)
     # calculate distances matrix

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ with open(path.join(path.abspath(path.dirname(__file__)), "README.md")) as f:
 
 setup(
     name="hammingdist",
-    version="0.12.0",
+    version="0.13.0",
     author="Dominic Kempf, Liam Keegan",
     author_email="ssc@iwr.uni-heidelberg.de",
     description="A fast tool to calculate Hamming distances",

--- a/src/bench.cc
+++ b/src/bench.cc
@@ -1,6 +1,7 @@
 #include "bench.hh"
 
 #include <array>
+#include <fstream>
 
 namespace hamming {
 
@@ -35,6 +36,19 @@ std::vector<std::string> make_stringlist(int64_t n, std::mt19937 &gen) {
     v.push_back(make_string(n, gen));
   }
   return v;
+}
+
+void write_fasta(const std::string &filename, const std::string &seq,
+                 std::size_t n_seq, std::mt19937 &gen) {
+  std::ofstream fs;
+  fs.open(filename);
+  for (std::size_t i = 0; i < n_seq; ++i) {
+    auto randomized_seq{seq};
+    // make ~0.5% of each sequence differ from seq
+    randomize_n(randomized_seq, seq.size() / 200, gen);
+    fs << ">seq" << i << "\n" << randomized_seq << "\n";
+  }
+  fs.close();
 }
 
 } // namespace hamming

--- a/src/bench.hh
+++ b/src/bench.hh
@@ -11,6 +11,8 @@ namespace hamming {
 std::string make_string(int64_t n, std::mt19937 &gen, bool include_dash = true);
 void randomize_n(std::string &str, std::size_t n, std::mt19937 &gen);
 std::vector<std::string> make_stringlist(int64_t n, std::mt19937 &gen);
+void write_fasta(const std::string &filename, const std::string &seq,
+                 std::size_t n_seq, std::mt19937 &gen);
 
 } // namespace hamming
 

--- a/src/hamming_bench.cc
+++ b/src/hamming_bench.cc
@@ -31,6 +31,17 @@ static void bench_from_stringlist_omp(benchmark::State &state) {
 }
 #endif
 
+static void bench_fasta_reference_distances(benchmark::State &state) {
+  std::mt19937 gen(12345);
+  std::string fasta_file{"fasta.txt"};
+  auto reference_seq{make_string(30000, gen, true)};
+  write_fasta(fasta_file, reference_seq, state.range(0), gen);
+  std::vector<ReferenceDistIntType> distances;
+  for (auto _ : state) {
+    distances = fasta_reference_distances(reference_seq, fasta_file, true);
+  }
+}
+
 BENCHMARK(bench_from_stringlist)
     ->RangeMultiplier(2)
     ->Range(128, 8192)
@@ -44,3 +55,7 @@ BENCHMARK(bench_from_stringlist_omp)
     ->Arg(12)
     ->Arg(24);
 #endif
+BENCHMARK(bench_fasta_reference_distances)
+    ->RangeMultiplier(2)
+    ->Range(16, 32384)
+    ->Complexity();

--- a/src/hamming_impl.cc
+++ b/src/hamming_impl.cc
@@ -58,16 +58,18 @@ std::vector<DistIntType> distances(std::vector<std::string> &data,
 
   // if X is included, we have to use the sparse distance function
   bool use_sparse = include_x;
-  // if < 0.5% of values differ from reference genome, also use sparse distance
-  // function
-  constexpr double sparse_threshold{0.005};
-  std::size_t n_diff{0};
-  for (const auto &s : sparse) {
-    n_diff += s.size() / 2;
+  // otherwise, use heuristic to choose distance function: if < 0.5% of values
+  // differ from reference genome, use sparse distance function
+  if (!include_x) {
+    constexpr double sparse_threshold{0.005};
+    std::size_t n_diff{0};
+    for (const auto &s : sparse) {
+      n_diff += s.size() / 2;
+    }
+    double frac_diff{static_cast<double>(n_diff) /
+                     static_cast<double>(nsamples * sample_length)};
+    use_sparse = frac_diff < sparse_threshold;
   }
-  double frac_diff{static_cast<double>(n_diff) /
-                   static_cast<double>(nsamples * sample_length)};
-  use_sparse = frac_diff < sparse_threshold;
   if (use_sparse) {
     if (clear_input_data) {
       data.clear();


### PR DESCRIPTION
- add `fasta_reference_distances`
  - calculates distance of each sequence in fasta file from supplied reference sequence
  - returns distances as numpy array
  - uses uint32 type to ensure very large distances are correctly determined
  - resolves #41
- ensure sparse distance method is always used if `include_x` is true
  - previously was only used if heuristic for use was also satisfied
- refactor python tests
- use c++17
