### PR TITLE
Use https for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,12 +4,12 @@
 
 [submodule "benchmark"]
 	path = ext/benchmark
-	url = git://github.com/google/benchmark.git
+	url = https://github.com/google/benchmark.git
 
 [submodule "cpu_features"]
 	path = ext/cpu_features
-	url = git://github.com/google/cpu_features.git
+	url = https://github.com/google/cpu_features.git
 
 [submodule "Catch2"]
 	path = ext/Catch2
-	url = git://github.com/catchorg/Catch2.git
+	url = https://github.com/catchorg/Catch2.git


### PR DESCRIPTION
GitHub no longer supports git://, see https://github.blog/2021-09-01-improving-git-protocol-security-github/