### PR TITLE
Improves performance of hammingdist

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,12 +4,12 @@
 
 [submodule "benchmark"]
 	path = ext/benchmark
-	url = git://github.com/google/benchmark.git
+	url = https://github.com/google/benchmark.git
 
 [submodule "cpu_features"]
 	path = ext/cpu_features
-	url = git://github.com/google/cpu_features.git
+	url = https://github.com/google/cpu_features.git
 
 [submodule "Catch2"]
 	path = ext/Catch2
-	url = git://github.com/catchorg/Catch2.git
+	url = https://github.com/catchorg/Catch2.git

--- a/src/hamming_impl.cc
+++ b/src/hamming_impl.cc
@@ -111,7 +111,7 @@ std::vector<DistIntType> distances(std::vector<std::string> &data,
 #endif
 
 #ifdef HAMMING_WITH_OPENMP
-#pragma omp parallel for
+#pragma omp parallel for schedule(static, 1)
 #endif
   for (std::size_t i = 0; i < nsamples; ++i) {
     std::size_t offset{i * (i - 1) / 2};

--- a/src/hamming_impl.cc
+++ b/src/hamming_impl.cc
@@ -94,9 +94,9 @@ std::vector<DistIntType> distances(std::vector<std::string> &data,
   const auto features = cpu_features::GetX86Info().features;
   int (*distance_func)(const std::vector<GeneBlock> &a,
                        const std::vector<GeneBlock> &b) = distance_cpp;
-#ifdef HAMMING_WITH_AVX512
-  if (features.avx512bw) {
-    distance_func = distance_avx512;
+#ifdef HAMMING_WITH_SSE2
+  if (features.sse2) {
+    distance_func = distance_sse2;
   }
 #endif
 #ifdef HAMMING_WITH_AVX2
@@ -104,11 +104,12 @@ std::vector<DistIntType> distances(std::vector<std::string> &data,
     distance_func = distance_avx2;
   }
 #endif
-#ifdef HAMMING_WITH_SSE2
-  if (features.sse2) {
-    distance_func = distance_sse2;
+#ifdef HAMMING_WITH_AVX512
+  if (features.avx512bw) {
+    distance_func = distance_avx512;
   }
 #endif
+
 #ifdef HAMMING_WITH_OPENMP
 #pragma omp parallel for
 #endif

--- a/src/hamming_impl.cc
+++ b/src/hamming_impl.cc
@@ -161,8 +161,8 @@ int distance_cpp(const std::vector<GeneBlock> &a,
   int r{0};
   for (std::size_t i = 0; i < a.size(); ++i) {
     auto c{static_cast<GeneBlock>(a[i] & b[i])};
-    r += static_cast<int>((c & mask_gene0) == 0);
-    r += static_cast<int>((c & mask_gene1) == 0);
+    r += static_cast<int>((c & mask_gene0) == 0) +
+         static_cast<int>((c & mask_gene1) == 0);
   }
   return r;
 }


### PR DESCRIPTION
Hello Liam, I have prepared a set of patches which improves performance of hammingdist use in the context of the covtrec project. You can review all the patches on https://github.com/ho-ob/hammingdist . If you are interested to get this patches into hammingdist I would create a pull request from there.

commit c86d0ae2254104fc243a915e8fbff1091b147ee0
This patch is non performance related. GitHub has changed there security policy and only allows git submodule checkout through secured connections.

commit fbf787ada34103fb53de3a6725c69ce3701bdca9
This patch changes the order in which the hardware features are checked. The most capable hardware feature is checked last so that it overwrites previously found less capable hardware features

commit ef63334a2f8e73970f7936af93c9d36ba06ec773
This patch adds a schedule directive for the OpenMP loop parallelization. Previously the scheduling was depending on the OpenMP runtime implementation. Normally this means, that the loop is divided in junks which a statically scheduled to the threads. This means a big load inbalance in our case, as the first thread always gets fewer work than the other threads because of the lower triangular shape of the matrix. The patch generates the best possible load balance by still keeping the overhead.

commit 886883e8ba24843102e37d536954ad74d47df92b
This patch speeds up generic distance computation. In my test case time went down from 1m12,219s to 0m46,584s. For comparision AVX2 implementation took 0m30,987s and SSE Implementation took 0m35,335s.

commit 74e3c91aeda77337c0f693759adc8a90ce59c310
This patch implements an OpenMP parallelized version of dump_lower_triangular. In a bigger testcase this bring execution time down from 61m42,280s to 16m40,637s. The non OpenMP version is not limited by the IO-subsystem but by the type conversion int -> string, which can be parallelized without overhead. Which adds an additional difficulty is the need to write the data ordered. This is the reason, why I used a static scheduling this time. So there are threads which finish with there work earlier but in sum even 4 threads are strong enough to hit the IO-limit.