### PR TITLE
use uint16 type for distance matrix elements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.11)
 
 project(
   hammingdist
-  VERSION 0.15.0
+  VERSION 0.16.0
   LANGUAGES CXX)
 
 include(CTest)

--- a/include/hamming/hamming_types.hh
+++ b/include/hamming/hamming_types.hh
@@ -8,7 +8,7 @@
 
 namespace hamming {
 
-using DistIntType = uint8_t;
+using DistIntType = uint16_t;
 using ReferenceDistIntType = uint32_t;
 
 struct DataSet {

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ with open(path.join(path.abspath(path.dirname(__file__)), "README.md")) as f:
 
 setup(
     name="hammingdist",
-    version="0.15.0",
+    version="0.16.0",
     author="Dominic Kempf, Liam Keegan",
     author_email="ssc@iwr.uni-heidelberg.de",
     description="A fast tool to calculate Hamming distances",


### PR DESCRIPTION
- values in the distance matrix now saturate at 65535 instead of 255
- bump version to 0.16.0
- resolves #54
