### PR TITLE
make `OpenMP::OpenMP_CXX` a `PUBLIC` dependency of libhamming

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.11)
 
 project(
   hammingdist
-  VERSION 0.18.0
+  VERSION 0.19.0
   LANGUAGES CXX)
 
 include(CTest)

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ with open(path.join(path.abspath(path.dirname(__file__)), "README.md")) as f:
 
 setup(
     name="hammingdist",
-    version="0.18.0",
+    version="0.19.0",
     author="Dominic Kempf, Liam Keegan",
     author_email="ssc@iwr.uni-heidelberg.de",
     description="A fast tool to calculate Hamming distances",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@ target_link_libraries(hamming PUBLIC CpuFeature::cpu_features)
 if(HAMMING_WITH_OPENMP)
   find_package(OpenMP REQUIRED)
   target_compile_definitions(hamming PUBLIC HAMMING_WITH_OPENMP)
-  target_link_libraries(hamming PRIVATE OpenMP::OpenMP_CXX)
+  target_link_libraries(hamming PUBLIC OpenMP::OpenMP_CXX)
 endif()
 
 # compile optional SIMD code as separate libraries which can be used at runtime


### PR DESCRIPTION
- ensures templated functions using openmp pragmas are parallelized
- resolves #86

also

- pybind11 -> 2.10.3
- bump hammingdist version
