### PR TITLE
re-enable tests for python 3.12 now that numpy 1.26 is released

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,14 @@ jobs:
             open-mp: "OFF"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
+          allow-prereleases: true
 
       - name: make build directory
         run: cmake -E make_directory ${{runner.workspace}}/build

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,11 +23,11 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
 
-      - uses: pypa/cibuildwheel@v2.15
+      - uses: pypa/cibuildwheel@v2.16
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.9.1
     hooks:
       - id: black
 
@@ -24,12 +24,12 @@ repos:
       - id: clang-format
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.1
+    rev: v3.0.3
     hooks:
       - id: prettier
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.24.1
+    rev: 0.26.3
     hooks:
       - id: check-github-workflows
       - id: check-readthedocs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,7 @@ HAMMING_BUILD_PYTHON = "ON"
 
 [tool.cibuildwheel]
 skip = "*-manylinux_i686"
-# skip tests for python 3.12 until numpy 1.26 is available
-test-skip = "pp* *-musllinux* cp312-*"
+test-skip = "pp* *-musllinux*"
 test-extras = "test"
 test-command = "pytest {project}/python/tests -v"
 environment = { BLAS="None", LAPACK="None", ATLAS="None" }


### PR DESCRIPTION
- also bump ci/pre-commit versions
- resolves #106
