### PR TITLE
Add max_distance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/psf/black
-    rev: 23.12.1
+    rev: 24.2.0
     hooks:
       - id: black
 
@@ -29,7 +29,7 @@ repos:
       - id: prettier
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.27.3
+    rev: 0.28.0
     hooks:
       - id: check-github-workflows
       - id: check-readthedocs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.23..3.27)
 
 project(
   hammingdist
-  VERSION 1.0.0
+  VERSION 1.1.0
   LANGUAGES CXX)
 
 include(CTest)

--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ import hammingdist
 sequence_indices = hammingdist.fasta_sequence_indices(fasta_file)
 ```
 
-## Large distance values
+## Maximum distance values
 
 By default, the elements in the distances matrix returned by `hammingdist.from_fasta` have a maximum value of 255.
-
+You can also set a smaller maximum value using the `max_distance` argument.
 For distances larger than this `hammingdist.from_fasta_large` supports distances up to 65535 (but uses twice as much RAM)
 
 ## Distances from reference sequence
@@ -122,12 +122,12 @@ On linux hammingdist is built with OpenMP (multithreading) support, and will aut
 ## CUDA on linux
 
 On linux hammingdist is also built with CUDA (Nvidia GPU) support.
-To use the GPU instead of the CPU, set `use_gpu=True` when calling `from_fasta`:
+To use the GPU instead of the CPU, set `use_gpu=True` when calling `from_fasta`. Here we also set the maximum distance to 2:
 
 ```python
 import hammingdist
 
-data = hammingdist.from_fasta("example.fasta", use_gpu=True)
+data = hammingdist.from_fasta("example.fasta", use_gpu=True, max_distance=2)
 ```
 
 Additionally, the lower triangular matrix file can now be directly constructed from the fasta file
@@ -138,7 +138,7 @@ which means it requires less RAM and runs faster.
 ```python
 import hammingdist
 
-hammingdist.from_fasta_to_lower_triangular('input_fasta.txt', 'output_lower_triangular.txt', use_gpu=True)
+hammingdist.from_fasta_to_lower_triangular('input_fasta.txt', 'output_lower_triangular.txt', use_gpu=True, max_distance=2)
 ```
 
 ![overview](plots/speed.png)

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(FMT_INSTALL OFF)
 add_subdirectory(fmt)
 
 if(HAMMING_BUILD_PYTHON)

--- a/include/hamming/distance_avx2.hh
+++ b/include/hamming/distance_avx2.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <limits>
 #include <vector>
 
 #include "hamming/hamming_impl_types.hh"
@@ -8,6 +9,7 @@
 namespace hamming {
 
 int distance_avx2(const std::vector<GeneBlock> &a,
-                  const std::vector<GeneBlock> &b);
+                  const std::vector<GeneBlock> &b,
+                  int max_dist = std::numeric_limits<int>::max());
 
 }

--- a/include/hamming/distance_avx512.hh
+++ b/include/hamming/distance_avx512.hh
@@ -4,10 +4,12 @@
 #include <vector>
 
 #include "hamming/hamming_impl_types.hh"
+#include <limits>
 
 namespace hamming {
 
 int distance_avx512(const std::vector<GeneBlock> &a,
-                    const std::vector<GeneBlock> &b);
+                    const std::vector<GeneBlock> &b,
+                    int max_dist = std::numeric_limits<int>::max());
 
 }

--- a/include/hamming/distance_cuda.hh
+++ b/include/hamming/distance_cuda.hh
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <iostream>
+#include <limits>
 #include <vector>
 
 #include "hamming/hamming_impl_types.hh"
@@ -11,17 +12,20 @@ namespace hamming {
 bool distance_cuda_have_device();
 
 int distance_cuda(const std::vector<GeneBlock> &a,
-                  const std::vector<GeneBlock> &b);
+                  const std::vector<GeneBlock> &b,
+                  int max_dist = std::numeric_limits<int>::max());
 
 // for now explicit function def for each choice of integer type
 std::vector<uint8_t>
-distances_cuda_8bit(const std::vector<std::vector<GeneBlock>> &data);
+distances_cuda_8bit(const std::vector<std::vector<GeneBlock>> &data,
+                    uint8_t max_dist = std::numeric_limits<uint8_t>::max());
 
 std::vector<uint16_t>
-distances_cuda_16bit(const std::vector<std::vector<GeneBlock>> &data);
+distances_cuda_16bit(const std::vector<std::vector<GeneBlock>> &data,
+                     uint16_t max_dist = std::numeric_limits<uint16_t>::max());
 
 void distances_cuda_to_lower_triangular(
     const std::vector<std::vector<GeneBlock>> &data,
-    const std::string &filename);
+    const std::string &filename, int max_distance);
 
 } // namespace hamming

--- a/include/hamming/distance_neon.hh
+++ b/include/hamming/distance_neon.hh
@@ -4,10 +4,12 @@
 #include <vector>
 
 #include "hamming/hamming_impl_types.hh"
+#include <limits>
 
 namespace hamming {
 
 int distance_neon(const std::vector<GeneBlock> &a,
-                  const std::vector<GeneBlock> &b);
+                  const std::vector<GeneBlock> &b,
+                  int max_dist = std::numeric_limits<int>::max());
 
 }

--- a/include/hamming/distance_sse2.hh
+++ b/include/hamming/distance_sse2.hh
@@ -4,10 +4,12 @@
 #include <vector>
 
 #include "hamming/hamming_impl_types.hh"
+#include <limits>
 
 namespace hamming {
 
 int distance_sse2(const std::vector<GeneBlock> &a,
-                  const std::vector<GeneBlock> &b);
+                  const std::vector<GeneBlock> &b,
+                  int max_dist = std::numeric_limits<int>::max());
 
 }

--- a/include/hamming/hamming.hh
+++ b/include/hamming/hamming.hh
@@ -19,10 +19,12 @@ template <typename DistIntType> struct DataSet {
   explicit DataSet(std::vector<std::string> &data, bool include_x = false,
                    bool clear_input_data = false,
                    std::vector<std::size_t> &&indices = {},
-                   bool use_gpu = false)
+                   bool use_gpu = false,
+                   int max_distance = std::numeric_limits<int>::max())
       : nsamples(data.size()), sequence_indices(std::move(indices)) {
     validate_data(data);
-    result = distances<DistIntType>(data, include_x, clear_input_data, use_gpu);
+    result = distances<DistIntType>(data, include_x, clear_input_data, use_gpu,
+                                    max_distance);
   }
 
   explicit DataSet(const std::string &filename) {
@@ -99,9 +101,10 @@ template <typename DistIntType> struct DataSet {
   std::vector<std::size_t> sequence_indices{};
 };
 
-DataSet<DefaultDistIntType> from_stringlist(std::vector<std::string> &data,
-                                            bool include_x = false,
-                                            bool use_gpu = false);
+DataSet<DefaultDistIntType>
+from_stringlist(std::vector<std::string> &data, bool include_x = false,
+                bool use_gpu = false,
+                int max_distance = std::numeric_limits<int>::max());
 
 DataSet<DefaultDistIntType> from_csv(const std::string &filename);
 
@@ -122,19 +125,21 @@ DataSet<DistIntType> from_lower_triangular(const std::string &filename) {
 }
 
 template <typename DistIntType>
-DataSet<DistIntType> from_fasta(const std::string &filename,
-                                bool include_x = false,
-                                bool remove_duplicates = false,
-                                std::size_t n = 0, bool use_gpu = false) {
+DataSet<DistIntType>
+from_fasta(const std::string &filename, bool include_x = false,
+           bool remove_duplicates = false, std::size_t n = 0,
+           bool use_gpu = false,
+           int max_distance = std::numeric_limits<int>::max()) {
   auto [data, sequence_indices] = read_fasta(filename, remove_duplicates, n);
   return DataSet<DistIntType>(data, include_x, true,
-                              std::move(sequence_indices), use_gpu);
+                              std::move(sequence_indices), use_gpu,
+                              max_distance);
 }
 
-void from_fasta_to_lower_triangular(const std::string &input_filename,
-                                    const std::string &output_filename,
-                                    bool remove_duplicates = false,
-                                    std::size_t n = 0, bool use_gpu = false);
+void from_fasta_to_lower_triangular(
+    const std::string &input_filename, const std::string &output_filename,
+    bool remove_duplicates = false, std::size_t n = 0, bool use_gpu = false,
+    int max_distance = std::numeric_limits<int>::max());
 
 ReferenceDistIntType distance(const std::string &seq0, const std::string &seq1,
                               bool include_x = false);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "hammingdist"
-version = "1.0.0"
+version = "1.1.0"
 description = "A fast tool to calculate Hamming distances"
 readme = "README.md"
 license = {text = "MIT"}

--- a/python/hammingdist.cc
+++ b/python/hammingdist.cc
@@ -60,25 +60,28 @@ PYBIND11_MODULE(hammingdist, m) {
   m.def("from_fasta", &from_fasta<uint8_t>, py::arg("filename"),
         py::arg("include_x") = false, py::arg("remove_duplicates") = false,
         py::arg("n") = 0, py::arg("use_gpu") = false,
+        py::arg("max_distance") = 255,
         "Creates a dataset by reading from a fasta file (assuming all "
         "sequences have equal length). Maximum value of an element in the "
-        "distances matrix: 255. Distances that would have been larger than "
-        "this value saturate at 255 - to support genomes with larger distances "
-        "than this see `from_fasta_large` instead.");
+        "distances matrix: max_distance or 255, whichever is lower."
+        "Distances that would have been larger than "
+        "this value instead saturate at this value - to support genomes with "
+        "larger distances than this see `from_fasta_large` instead.");
   m.def("from_fasta_large", &from_fasta<uint16_t>, py::arg("filename"),
         py::arg("include_x") = false, py::arg("remove_duplicates") = false,
         py::arg("n") = 0, py::arg("use_gpu") = false,
+        py::arg("max_distance") = 65535,
         "Creates a dataset by reading from a fasta file (assuming all "
         "sequences have equal length). Maximum value of an element in the "
-        "distances matrix: 65535");
+        "distances matrix: max_distance or 65535, whichever is lower");
   m.def("from_fasta_to_lower_triangular", &from_fasta_to_lower_triangular,
         py::arg("fasta_filename"), py::arg("output_filename"),
         py::arg("remove_duplicates") = false, py::arg("n") = 0,
-        py::arg("use_gpu") = true,
+        py::arg("use_gpu") = true, py::arg("max_distance") = 65535,
         "Construct lower triangular distances matrix output file from the "
         "fasta file,"
         "requires an NVIDIA GPU. Maximum value of an element in "
-        "the distances matrix: 65535");
+        "the distances matrix: max_distance or 65535, whichever is lower");
   m.def("from_lower_triangular", &from_lower_triangular<uint8_t>,
         "Creates a dataset by reading already computed distances from lower "
         "triangular format. Maximum value of an element in the distances "

--- a/src/bench.cc
+++ b/src/bench.cc
@@ -40,13 +40,14 @@ std::vector<std::string> make_stringlist(int64_t n, int64_t n_samples,
 }
 
 void write_fasta(const std::string &filename, const std::string &seq,
-                 std::size_t n_seq, std::mt19937 &gen) {
+                 std::size_t n_seq, std::mt19937 &gen,
+                 std::size_t randomise_every_n) {
   std::ofstream fs;
   fs.open(filename);
   for (std::size_t i = 0; i < n_seq; ++i) {
     auto randomized_seq{seq};
-    // make ~0.5% of each sequence differ from seq
-    randomize_n(randomized_seq, seq.size() / 200, gen);
+    // randomly replace 1 in randomise_every_n elements of seq
+    randomize_n(randomized_seq, seq.size() / randomise_every_n, gen);
     fs << ">seq" << i << "\n" << randomized_seq << "\n";
   }
   fs.close();

--- a/src/bench.hh
+++ b/src/bench.hh
@@ -15,7 +15,8 @@ std::vector<std::string> make_stringlist(int64_t n, int64_t n_samples,
                                          std::mt19937 &gen);
 
 void write_fasta(const std::string &filename, const std::string &seq,
-                 std::size_t n_seq, std::mt19937 &gen);
+                 std::size_t n_seq, std::mt19937 &gen,
+                 std::size_t randomise_every_n = 200);
 
 template <typename DistIntType>
 std::vector<DistIntType> make_distances(int64_t n, std::mt19937 &gen) {

--- a/src/distance_avx2_t.cc
+++ b/src/distance_avx2_t.cc
@@ -16,9 +16,12 @@ TEST_CASE("distance_avx2() returns all return zero for identical vectors",
         32767,   32768,  32769,  65535,  65536,  65537,  131071, 131072,
         131073,  262143, 262144, 262145, 524287, 524288, 524289, 1048575,
         1048576, 1048577}) {
-    CAPTURE(n);
-    auto g1{make_gene_vector(n, gen)};
-    REQUIRE(distance_avx2(g1, g1) == 0);
+    for (int max_dist : {0, 1, 2, 11, 999, 9876544}) {
+      CAPTURE(n);
+      CAPTURE(max_dist);
+      auto g1{make_gene_vector(n, gen)};
+      REQUIRE(distance_avx2(g1, g1, max_dist) == 0);
+    }
   }
 }
 
@@ -34,10 +37,13 @@ TEST_CASE("distance_avx2() all return n for n A's and n G's",
         32767,   32768,  32769,  65535,  65536,  65537,  131071, 131072,
         131073,  262143, 262144, 262145, 524287, 524288, 524289, 1048575,
         1048576, 1048577}) {
-    CAPTURE(n);
-    auto g1 = from_string(std::string(n, 'A'));
-    auto g2 = from_string(std::string(n, 'G'));
-    REQUIRE(distance_avx2(g1, g2) == n);
+    for (int max_dist : {0, 1, 2, 11, 999, 9876544}) {
+      CAPTURE(n);
+      CAPTURE(max_dist);
+      auto g1 = from_string(std::string(n, 'A'));
+      auto g2 = from_string(std::string(n, 'G'));
+      REQUIRE(distance_avx2(g1, g2, max_dist) == std::min(max_dist, n));
+    }
   }
 }
 
@@ -54,9 +60,13 @@ TEST_CASE("distance_avx2() returns same as distance_cpp() for random vectors",
         32767,   32768,  32769,  65535,  65536,  65537,  131071, 131072,
         131073,  262143, 262144, 262145, 524287, 524288, 524289, 1048575,
         1048576, 1048577}) {
-    CAPTURE(n);
-    auto g1{make_gene_vector(n, gen)};
-    auto g2{make_gene_vector(n, gen)};
-    REQUIRE(distance_avx2(g1, g2) == distance_cpp(g1, g2));
+    for (int max_dist : {0, 1, 2, 11, 999, 9876544}) {
+      CAPTURE(n);
+      CAPTURE(max_dist);
+      auto g1{make_gene_vector(n, gen)};
+      auto g2{make_gene_vector(n, gen)};
+      REQUIRE(distance_avx2(g1, g2, max_dist) ==
+              distance_cpp(g1, g2, max_dist));
+    }
   }
 }

--- a/src/distance_avx512.cc
+++ b/src/distance_avx512.cc
@@ -4,7 +4,7 @@
 namespace hamming {
 
 int distance_avx512(const std::vector<GeneBlock> &a,
-                    const std::vector<GeneBlock> &b) {
+                    const std::vector<GeneBlock> &b, int max_dist) {
   // distance implementation using AVX512 simd intrinsics
   // a 512-bit register holds 64 GeneBlocks, i.e. 128 genes
   constexpr std::size_t n_geneblocks{64};
@@ -26,8 +26,11 @@ int distance_avx512(const std::vector<GeneBlock> &a,
   std::size_t n_iter{a.size() / n_geneblocks};
   // each partial distance count is stored in a unit8, so max value = 255,
   // and the value can be increased by at most 2 with each iteration,
-  // so we do 127 inner iterations for a max value of 254 to avoid overflow
-  std::size_t n_inner{127};
+  // so up to 127 inner iterations for a max value of 254 avoid overflow.
+  // if max_dist is large then we maximise the number of inner iterations, but
+  // if it is small then we do fewer inner iterations to allow more
+  // opportunities to return early if we have reached max_dist
+  std::size_t n_inner = max_dist >= 255 ? 127 : 16;
   std::size_t n_outer{1 + n_iter / n_inner};
   for (std::size_t j = 0; j < n_outer; ++j) {
     std::size_t n{std::min((j + 1) * n_inner, n_iter)};
@@ -59,6 +62,9 @@ int distance_avx512(const std::vector<GeneBlock> &a,
     for (std::size_t i = 0; i < n_partialsums; ++i) {
       r += r_partial[i];
     }
+    if (r >= max_dist) {
+      return max_dist;
+    }
   }
   // do last partial block without simd intrinsics
   for (std::size_t i = n_geneblocks * n_iter; i < a.size(); ++i) {
@@ -66,7 +72,7 @@ int distance_avx512(const std::vector<GeneBlock> &a,
     r += static_cast<int>((c & mask_gene0) == 0);
     r += static_cast<int>((c & mask_gene1) == 0);
   }
-  return r;
+  return std::min(max_dist, r);
 }
 
 } // namespace hamming

--- a/src/distance_avx512_t.cc
+++ b/src/distance_avx512_t.cc
@@ -17,9 +17,12 @@ TEST_CASE("distance_avx512() returns all return zero for identical vectors",
         32767,   32768,  32769,  65535,  65536,  65537,  131071, 131072,
         131073,  262143, 262144, 262145, 524287, 524288, 524289, 1048575,
         1048576, 1048577}) {
-    CAPTURE(n);
-    auto g1{make_gene_vector(n, gen)};
-    REQUIRE(distance_avx512(g1, g1) == 0);
+    for (int max_dist : {0, 1, 2, 11, 999, 9876544}) {
+      CAPTURE(n);
+      CAPTURE(max_dist);
+      auto g1{make_gene_vector(n, gen)};
+      REQUIRE(distance_avx512(g1, g1, max_dist) == 0);
+    }
   }
 }
 
@@ -35,10 +38,13 @@ TEST_CASE("distance_avx512() all return n for n A's and n G's",
         32767,   32768,  32769,  65535,  65536,  65537,  131071, 131072,
         131073,  262143, 262144, 262145, 524287, 524288, 524289, 1048575,
         1048576, 1048577}) {
-    CAPTURE(n);
-    auto g1 = from_string(std::string(n, 'A'));
-    auto g2 = from_string(std::string(n, 'G'));
-    REQUIRE(distance_avx512(g1, g2) == n);
+    for (int max_dist : {0, 1, 2, 11, 999, 9876544}) {
+      CAPTURE(n);
+      CAPTURE(max_dist);
+      auto g1 = from_string(std::string(n, 'A'));
+      auto g2 = from_string(std::string(n, 'G'));
+      REQUIRE(distance_avx512(g1, g2, max_dist) == std::min(max_dist, n));
+    }
   }
 }
 
@@ -55,9 +61,13 @@ TEST_CASE("distance_avx512() returns same as distance_cpp() for random vectors",
         32767,   32768,  32769,  65535,  65536,  65537,  131071, 131072,
         131073,  262143, 262144, 262145, 524287, 524288, 524289, 1048575,
         1048576, 1048577}) {
-    CAPTURE(n);
-    auto g1{make_gene_vector(n, gen)};
-    auto g2{make_gene_vector(n, gen)};
-    REQUIRE(distance_avx512(g1, g2) == distance_cpp(g1, g2));
+    for (int max_dist : {0, 1, 2, 11, 999, 9876544}) {
+      CAPTURE(n);
+      CAPTURE(max_dist);
+      auto g1{make_gene_vector(n, gen)};
+      auto g2{make_gene_vector(n, gen)};
+      REQUIRE(distance_avx512(g1, g2, max_dist) ==
+              distance_cpp(g1, g2, max_dist));
+    }
   }
 }

--- a/src/distance_cuda_t.cc
+++ b/src/distance_cuda_t.cc
@@ -16,9 +16,12 @@ TEST_CASE("distance_cuda() returns all return zero for identical vectors",
         32767,   32768,  32769,  65535,  65536,  65537,  131071, 131072,
         131073,  262143, 262144, 262145, 524287, 524288, 524289, 1048575,
         1048576, 1048577}) {
-    CAPTURE(n);
-    auto g1{make_gene_vector(n, gen)};
-    REQUIRE(distance_cuda(g1, g1) == 0);
+    for (int max_dist : {0, 1, 2, 11, 999, 9876544}) {
+      CAPTURE(n);
+      CAPTURE(max_dist);
+      auto g1{make_gene_vector(n, gen)};
+      REQUIRE(distance_cuda(g1, g1, max_dist) == 0);
+    }
   }
 }
 
@@ -34,10 +37,13 @@ TEST_CASE("distance_cuda() all return n for n A's and n G's",
         32767,   32768,  32769,  65535,  65536,  65537,  131071, 131072,
         131073,  262143, 262144, 262145, 524287, 524288, 524289, 1048575,
         1048576, 1048577}) {
-    CAPTURE(n);
-    auto g1 = from_string(std::string(n, 'A'));
-    auto g2 = from_string(std::string(n, 'G'));
-    REQUIRE(distance_cuda(g1, g2) == n);
+    for (int max_dist : {0, 1, 2, 11, 999, 9876544}) {
+      CAPTURE(n);
+      CAPTURE(max_dist);
+      auto g1 = from_string(std::string(n, 'A'));
+      auto g2 = from_string(std::string(n, 'G'));
+      REQUIRE(distance_cuda(g1, g2, max_dist) == std::min(max_dist, n));
+    }
   }
 }
 
@@ -54,9 +60,13 @@ TEST_CASE("distance_cuda() returns same as distance_cpp() for random vectors",
         32767,   32768,  32769,  65535,  65536,  65537,  131071, 131072,
         131073,  262143, 262144, 262145, 524287, 524288, 524289, 1048575,
         1048576, 1048577}) {
-    CAPTURE(n);
-    auto g1{make_gene_vector(n, gen)};
-    auto g2{make_gene_vector(n, gen)};
-    REQUIRE(distance_cuda(g1, g2) == distance_cpp(g1, g2));
+    for (int max_dist : {0, 1, 2, 11, 999, 9876544}) {
+      CAPTURE(n);
+      CAPTURE(max_dist);
+      auto g1{make_gene_vector(n, gen)};
+      auto g2{make_gene_vector(n, gen)};
+      REQUIRE(distance_cuda(g1, g2, max_dist) ==
+              distance_cpp(g1, g2, max_dist));
+    }
   }
 }

--- a/src/distance_neon.cc
+++ b/src/distance_neon.cc
@@ -4,7 +4,7 @@
 namespace hamming {
 
 int distance_neon(const std::vector<GeneBlock> &a,
-                  const std::vector<GeneBlock> &b) {
+                  const std::vector<GeneBlock> &b, int max_dist) {
   // distance implementation using NEON simd intrinsics
   // a 128-bit register holds 16 GeneBlocks, i.e. 32 genes
   constexpr std::size_t n_geneblocks{16};
@@ -24,8 +24,11 @@ int distance_neon(const std::vector<GeneBlock> &a,
   std::size_t n_iter{a.size() / n_geneblocks};
   // each partial distance count is stored in a uint8, so max value = 255,
   // and the value can be increased by at most 2 with each iteration,
-  // so we do 127 inner iterations for a max value of 254 to avoid overflow
-  std::size_t n_inner{127};
+  // so up to 127 inner iterations for a max value of 254 avoid overflow.
+  // if max_dist is large then we maximise the number of inner iterations, but
+  // if it is small then we do fewer inner iterations to allow more
+  // opportunities to return early if we have reached max_dist
+  std::size_t n_inner = max_dist >= 255 ? 127 : 16;
   std::size_t n_outer{1 + n_iter / n_inner};
   for (std::size_t j = 0; j < n_outer; ++j) {
     std::size_t n{std::min((j + 1) * n_inner, n_iter)};
@@ -52,6 +55,9 @@ int distance_neon(const std::vector<GeneBlock> &a,
     }
     // sum the 16 distances in r_s & add to r
     r += vaddlvq_u8(r_s);
+    if (r >= max_dist) {
+      return max_dist;
+    }
   }
   // do last partial block without simd intrinsics
   for (std::size_t i = n_geneblocks * n_iter; i < a.size(); ++i) {
@@ -59,7 +65,7 @@ int distance_neon(const std::vector<GeneBlock> &a,
     r += static_cast<int>((c & mask_gene0) == 0);
     r += static_cast<int>((c & mask_gene1) == 0);
   }
-  return r;
+  return std::min(max_dist, r);
 }
 
 } // namespace hamming

--- a/src/distance_neon_t.cc
+++ b/src/distance_neon_t.cc
@@ -16,9 +16,12 @@ TEST_CASE("distance_neon() returns all return zero for identical vectors",
         32767,   32768,  32769,  65535,  65536,  65537,  131071, 131072,
         131073,  262143, 262144, 262145, 524287, 524288, 524289, 1048575,
         1048576, 1048577}) {
-    CAPTURE(n);
-    auto g1{make_gene_vector(n, gen)};
-    REQUIRE(distance_neon(g1, g1) == 0);
+    for (int max_dist : {0, 1, 2, 11, 999, 9876544}) {
+      CAPTURE(n);
+      CAPTURE(max_dist);
+      auto g1{make_gene_vector(n, gen)};
+      REQUIRE(distance_neon(g1, g1, max_dist) == 0);
+    }
   }
 }
 
@@ -34,10 +37,13 @@ TEST_CASE("distance_neon() all return n for n A's and n G's",
         32767,   32768,  32769,  65535,  65536,  65537,  131071, 131072,
         131073,  262143, 262144, 262145, 524287, 524288, 524289, 1048575,
         1048576, 1048577}) {
-    CAPTURE(n);
-    auto g1 = from_string(std::string(n, 'A'));
-    auto g2 = from_string(std::string(n, 'G'));
-    REQUIRE(distance_neon(g1, g2) == n);
+    for (int max_dist : {0, 1, 2, 11, 999, 9876544}) {
+      CAPTURE(n);
+      CAPTURE(max_dist);
+      auto g1 = from_string(std::string(n, 'A'));
+      auto g2 = from_string(std::string(n, 'G'));
+      REQUIRE(distance_neon(g1, g2, max_dist) == std::min(max_dist, n));
+    }
   }
 }
 
@@ -54,9 +60,13 @@ TEST_CASE("distance_neon() returns same as distance_cpp() for random vectors",
         32767,   32768,  32769,  65535,  65536,  65537,  131071, 131072,
         131073,  262143, 262144, 262145, 524287, 524288, 524289, 1048575,
         1048576, 1048577}) {
-    CAPTURE(n);
-    auto g1{make_gene_vector(n, gen)};
-    auto g2{make_gene_vector(n, gen)};
-    REQUIRE(distance_neon(g1, g2) == distance_cpp(g1, g2));
+    for (int max_dist : {0, 1, 2, 11, 999, 9876544}) {
+      CAPTURE(n);
+      CAPTURE(max_dist);
+      auto g1{make_gene_vector(n, gen)};
+      auto g2{make_gene_vector(n, gen)};
+      REQUIRE(distance_neon(g1, g2, max_dist) ==
+              distance_cpp(g1, g2, max_dist));
+    }
   }
 }

--- a/src/distance_sse2.cc
+++ b/src/distance_sse2.cc
@@ -4,7 +4,7 @@
 namespace hamming {
 
 int distance_sse2(const std::vector<GeneBlock> &a,
-                  const std::vector<GeneBlock> &b) {
+                  const std::vector<GeneBlock> &b, int max_dist) {
   // distance implementation using SSE2 simd intrinsics
   // a 128-bit register holds 16 GeneBlocks, i.e. 32 genes
   constexpr std::size_t n_geneblocks{16};
@@ -24,8 +24,11 @@ int distance_sse2(const std::vector<GeneBlock> &a,
   std::size_t n_iter{a.size() / n_geneblocks};
   // each partial distance count is stored in a unit8, so max value = 255,
   // and the value can be increased by at most 2 with each iteration,
-  // so we do 127 inner iterations for a max value of 254 to avoid overflow
-  std::size_t n_inner{127};
+  // so up to 127 inner iterations for a max value of 254 avoid overflow.
+  // if max_dist is large then we maximise the number of inner iterations, but
+  // if it is small then we do fewer inner iterations to allow more
+  // opportunities to return early if we have reached max_dist
+  std::size_t n_inner = max_dist >= 255 ? 127 : 16;
   std::size_t n_outer{1 + n_iter / n_inner};
   for (std::size_t j = 0; j < n_outer; ++j) {
     std::size_t n{std::min((j + 1) * n_inner, n_iter)};
@@ -60,6 +63,9 @@ int distance_sse2(const std::vector<GeneBlock> &a,
     for (std::size_t i = 0; i < n_partialsums; ++i) {
       r += r_partial[i];
     }
+    if (r >= max_dist) {
+      return max_dist;
+    }
   }
   // do last partial block without simd intrinsics
   for (std::size_t i = n_geneblocks * n_iter; i < a.size(); ++i) {
@@ -67,7 +73,7 @@ int distance_sse2(const std::vector<GeneBlock> &a,
     r += static_cast<int>((c & mask_gene0) == 0);
     r += static_cast<int>((c & mask_gene1) == 0);
   }
-  return r;
+  return std::min(max_dist, r);
 }
 
 } // namespace hamming

--- a/src/distance_sse2_t.cc
+++ b/src/distance_sse2_t.cc
@@ -16,9 +16,12 @@ TEST_CASE("distance_sse2() returns all return zero for identical vectors",
         32767,   32768,  32769,  65535,  65536,  65537,  131071, 131072,
         131073,  262143, 262144, 262145, 524287, 524288, 524289, 1048575,
         1048576, 1048577}) {
-    CAPTURE(n);
-    auto g1{make_gene_vector(n, gen)};
-    REQUIRE(distance_sse2(g1, g1) == 0);
+    for (int max_dist : {0, 1, 2, 11, 999, 9876544}) {
+      CAPTURE(n);
+      CAPTURE(max_dist);
+      auto g1{make_gene_vector(n, gen)};
+      REQUIRE(distance_sse2(g1, g1, max_dist) == 0);
+    }
   }
 }
 
@@ -34,10 +37,13 @@ TEST_CASE("distance_sse2() all return n for n A's and n G's",
         32767,   32768,  32769,  65535,  65536,  65537,  131071, 131072,
         131073,  262143, 262144, 262145, 524287, 524288, 524289, 1048575,
         1048576, 1048577}) {
-    CAPTURE(n);
-    auto g1 = from_string(std::string(n, 'A'));
-    auto g2 = from_string(std::string(n, 'G'));
-    REQUIRE(distance_sse2(g1, g2) == n);
+    for (int max_dist : {0, 1, 2, 11, 999, 9876544}) {
+      CAPTURE(n);
+      CAPTURE(max_dist);
+      auto g1 = from_string(std::string(n, 'A'));
+      auto g2 = from_string(std::string(n, 'G'));
+      REQUIRE(distance_sse2(g1, g2, max_dist) == std::min(max_dist, n));
+    }
   }
 }
 
@@ -54,9 +60,13 @@ TEST_CASE("distance_sse2() returns same as distance_cpp() for random vectors",
         32767,   32768,  32769,  65535,  65536,  65537,  131071, 131072,
         131073,  262143, 262144, 262145, 524287, 524288, 524289, 1048575,
         1048576, 1048577}) {
-    CAPTURE(n);
-    auto g1{make_gene_vector(n, gen)};
-    auto g2{make_gene_vector(n, gen)};
-    REQUIRE(distance_sse2(g1, g2) == distance_cpp(g1, g2));
+    for (int max_dist : {0, 1, 2, 11, 999, 9876544}) {
+      CAPTURE(n);
+      CAPTURE(max_dist);
+      auto g1{make_gene_vector(n, gen)};
+      auto g2{make_gene_vector(n, gen)};
+      REQUIRE(distance_sse2(g1, g2, max_dist) ==
+              distance_cpp(g1, g2, max_dist));
+    }
   }
 }

--- a/src/hamming.cc
+++ b/src/hamming.cc
@@ -14,8 +14,10 @@
 namespace hamming {
 
 DataSet<DefaultDistIntType> from_stringlist(std::vector<std::string> &data,
-                                            bool include_x, bool use_gpu) {
-  return DataSet<DefaultDistIntType>(data, include_x, false, {}, use_gpu);
+                                            bool include_x, bool use_gpu,
+                                            int max_distance) {
+  return DataSet<DefaultDistIntType>(data, include_x, false, {}, use_gpu,
+                                     max_distance);
 }
 
 DataSet<DefaultDistIntType> from_csv(const std::string &filename) {
@@ -25,7 +27,7 @@ DataSet<DefaultDistIntType> from_csv(const std::string &filename) {
 void from_fasta_to_lower_triangular(const std::string &input_filename,
                                     const std::string &output_filename,
                                     bool remove_duplicates, std::size_t n,
-                                    bool use_gpu) {
+                                    bool use_gpu, int max_distance) {
   if (use_gpu) {
     std::cout << "# hammingdist :: Using GPU..." << std::endl;
   }
@@ -40,7 +42,8 @@ void from_fasta_to_lower_triangular(const std::string &input_filename,
             << " ms..." << std::endl;
 #ifdef HAMMING_WITH_CUDA
   if (use_gpu) {
-    distances_cuda_to_lower_triangular(dense_data, output_filename);
+    distances_cuda_to_lower_triangular(dense_data, output_filename,
+                                       max_distance);
     return;
   }
 #endif

--- a/src/hamming_impl.cc
+++ b/src/hamming_impl.cc
@@ -90,7 +90,7 @@ void validate_data(const std::vector<std::string> &data) {
   }
 }
 
-int distance_sparse(const SparseData &a, const SparseData &b) {
+int distance_sparse(const SparseData &a, const SparseData &b, int max_dist) {
   int r{0};
   std::size_t ia{0};
   std::size_t ib{0};
@@ -113,6 +113,9 @@ int distance_sparse(const SparseData &a, const SparseData &b) {
       ia += 2;
       ib += 2;
     }
+    if (r >= max_dist) {
+      return max_dist;
+    }
   }
   while (ia < a.size()) {
     r += static_cast<int>(a[ia + 1] != 0xff);
@@ -122,18 +125,18 @@ int distance_sparse(const SparseData &a, const SparseData &b) {
     r += static_cast<int>(b[ib + 1] != 0xff);
     ib += 2;
   }
-  return r;
+  return std::min(r, max_dist);
 }
 
 int distance_cpp(const std::vector<GeneBlock> &a,
-                 const std::vector<GeneBlock> &b) {
+                 const std::vector<GeneBlock> &b, int max_dist) {
   int r{0};
   for (std::size_t i = 0; i < a.size(); ++i) {
     auto c{static_cast<GeneBlock>(a[i] & b[i])};
     r += static_cast<int>((c & mask_gene0) == 0) +
          static_cast<int>((c & mask_gene1) == 0);
   }
-  return r;
+  return std::min(r, max_dist);
 }
 
 static std::string

--- a/src/hamming_impl_t.cc
+++ b/src/hamming_impl_t.cc
@@ -16,9 +16,12 @@ TEST_CASE("distance_cpp() returns zero for identical vectors of valid chars",
         32767,   32768,  32769,  65535,  65536,  65537,  131071, 131072,
         131073,  262143, 262144, 262145, 524287, 524288, 524289, 1048575,
         1048576, 1048577}) {
-    CAPTURE(n);
-    auto g1{make_gene_vector(n, gen)};
-    REQUIRE(distance_cpp(g1, g1) == 0);
+    for (int max_dist : {0, 1, 2, 11, 999, 9876544}) {
+      CAPTURE(n);
+      CAPTURE(max_dist);
+      auto g1{make_gene_vector(n, gen)};
+      REQUIRE(distance_cpp(g1, g1, max_dist) == 0);
+    }
   }
 }
 
@@ -33,10 +36,13 @@ TEST_CASE("distance_cpp() returns n for n A's and n G's", "[impl][distance]") {
         32767,   32768,  32769,  65535,  65536,  65537,  131071, 131072,
         131073,  262143, 262144, 262145, 524287, 524288, 524289, 1048575,
         1048576, 1048577}) {
-    CAPTURE(n);
-    auto g1 = from_string(std::string(n, 'A'));
-    auto g2 = from_string(std::string(n, 'G'));
-    REQUIRE(distance_cpp(g1, g2) == n);
+    for (int max_dist : {0, 1, 2, 11, 999, 9876544}) {
+      CAPTURE(n);
+      CAPTURE(max_dist);
+      auto g1 = from_string(std::string(n, 'A'));
+      auto g2 = from_string(std::string(n, 'G'));
+      REQUIRE(distance_cpp(g1, g2, max_dist) == std::min(max_dist, n));
+    }
   }
 }
 
@@ -53,12 +59,15 @@ TEST_CASE("distance_sparse() returns zero for identical vectors of valid chars",
         32767,   32768,  32769,  65535,  65536,  65537,  131071, 131072,
         131073,  262143, 262144, 262145, 524287, 524288, 524289, 1048575,
         1048576, 1048577}) {
-    CAPTURE(n);
-    for (bool include_x : {false, true}) {
-      auto g1{make_test_string(n, gen, include_x)};
-      CAPTURE(include_x);
-      auto sparse = to_sparse_data({g1, g1}, include_x);
-      REQUIRE(distance_sparse(sparse[0], sparse[1]) == 0);
+    for (int max_dist : {0, 1, 2, 11, 999, 9876544}) {
+      CAPTURE(n);
+      CAPTURE(max_dist);
+      for (bool include_x : {false, true}) {
+        auto g1{make_test_string(n, gen, include_x)};
+        CAPTURE(include_x);
+        auto sparse = to_sparse_data({g1, g1}, include_x);
+        REQUIRE(distance_sparse(sparse[0], sparse[1], max_dist) == 0);
+      }
     }
   }
 }
@@ -75,15 +84,19 @@ TEST_CASE("distance_sparse() returns n for n A's and n G's",
         32767,   32768,  32769,  65535,  65536,  65537,  131071, 131072,
         131073,  262143, 262144, 262145, 524287, 524288, 524289, 1048575,
         1048576, 1048577}) {
-    CAPTURE(n);
-    for (char c1 : {'A', 'X'}) {
-      for (char c2 : {'G', 'T'}) {
-        auto g1 = std::string(n, c1);
-        auto g2 = std::string(n, c2);
-        for (bool include_x : {false, true}) {
-          CAPTURE(include_x);
-          auto sparse = to_sparse_data({g1, g2}, include_x);
-          REQUIRE(distance_sparse(sparse[0], sparse[1]) == n);
+    for (int max_dist : {0, 1, 2, 11, 999, 9876544}) {
+      CAPTURE(n);
+      CAPTURE(max_dist);
+      for (char c1 : {'A', 'X'}) {
+        for (char c2 : {'G', 'T'}) {
+          auto g1 = std::string(n, c1);
+          auto g2 = std::string(n, c2);
+          for (bool include_x : {false, true}) {
+            CAPTURE(include_x);
+            auto sparse = to_sparse_data({g1, g2}, include_x);
+            REQUIRE(distance_sparse(sparse[0], sparse[1], max_dist) ==
+                    std::min(max_dist, n));
+          }
         }
       }
     }
@@ -104,15 +117,19 @@ TEST_CASE("distance_sparse() returns same as distance_cpp() for random vectors "
         32767,   32768,  32769,  65535,  65536,  65537,  131071, 131072,
         131073,  262143, 262144, 262145, 524287, 524288, 524289, 1048575,
         1048576, 1048577}) {
-    CAPTURE(n);
-    auto s1{make_test_string(n, gen)};
-    auto s2{make_test_string(n, gen)};
-    auto g1{from_string(s1)};
-    auto g2{from_string(s2)};
-    for (bool include_x : {false, true}) {
-      CAPTURE(include_x);
-      auto sparse = to_sparse_data({s1, s2}, include_x);
-      REQUIRE(distance_sparse(sparse[0], sparse[1]) == distance_cpp(g1, g2));
+    for (int max_dist : {0, 1, 2, 11, 999, 9876544}) {
+      CAPTURE(n);
+      CAPTURE(max_dist);
+      auto s1{make_test_string(n, gen)};
+      auto s2{make_test_string(n, gen)};
+      auto g1{from_string(s1)};
+      auto g2{from_string(s2)};
+      for (bool include_x : {false, true}) {
+        CAPTURE(include_x);
+        auto sparse = to_sparse_data({s1, s2}, include_x);
+        REQUIRE(distance_sparse(sparse[0], sparse[1], max_dist) ==
+                distance_cpp(g1, g2, max_dist));
+      }
     }
   }
 }
@@ -131,30 +148,33 @@ TEST_CASE("distance_sparse() returns same as distance_cpp() for equal-distance "
         32767,   32768,  32769,  65535,  65536,  65537,  131071, 131072,
         131073,  262143, 262144, 262145, 524287, 524288, 524289, 1048575,
         1048576, 1048577}) {
-    CAPTURE(n);
-    // calculate distance of strings with no X's
-    auto s1{make_test_string(n, gen)};
-    auto s2{make_test_string(n, gen)};
-    auto g1{from_string(s1)};
-    auto g2{from_string(s2)};
-    auto dist = distance_cpp(g1, g2);
-    // replace all A's with X's : sparse distance with X as valid char should be
-    // the same
-    for (char replace_char : {'A', 'C', 'G', 'T'}) {
-      auto s1_x = s1;
-      auto s2_x = s2;
-      for (auto &c : s1_x) {
-        if (c == replace_char) {
-          c = 'X';
+    for (int max_dist : {0, 1, 2, 11, 999, 9876544}) {
+      CAPTURE(n);
+      CAPTURE(max_dist);
+      // calculate distance of strings with no X's
+      auto s1{make_test_string(n, gen)};
+      auto s2{make_test_string(n, gen)};
+      auto g1{from_string(s1)};
+      auto g2{from_string(s2)};
+      auto dist = distance_cpp(g1, g2, max_dist);
+      // replace all A's with X's : sparse distance with X as valid char should
+      // be the same
+      for (char replace_char : {'A', 'C', 'G', 'T'}) {
+        auto s1_x = s1;
+        auto s2_x = s2;
+        for (auto &c : s1_x) {
+          if (c == replace_char) {
+            c = 'X';
+          }
         }
-      }
-      for (auto &c : s2_x) {
-        if (c == replace_char) {
-          c = 'X';
+        for (auto &c : s2_x) {
+          if (c == replace_char) {
+            c = 'X';
+          }
         }
+        auto sparse = to_sparse_data({s1_x, s2_x}, true);
+        REQUIRE(distance_sparse(sparse[0], sparse[1], max_dist) == dist);
       }
-      auto sparse = to_sparse_data({s1_x, s2_x}, true);
-      REQUIRE(distance_sparse(sparse[0], sparse[1]) == dist);
     }
   }
 }


### PR DESCRIPTION
- distance functions have a `max_distance` argument
- default value is max value for that type of int (i.e. unchanged)
- CPU distance implementations now return early if the distance reached max_distance
  - for max_distance < 255 we do more intermediate summing of distances to allow early return -> slight reduction in performance if no early return
- add benchmarks and tests
- bump version
- resolves #117
